### PR TITLE
fix: 更新东财下单检查可用金额问题

### DIFF
--- a/easytrader/eastmoney_trader.py
+++ b/easytrader/eastmoney_trader.py
@@ -355,7 +355,7 @@ class EastMoneyTrader(webtrader.WebTrader):
         balance = self.get_balance()[0]
         if not volume:
             volume = int(float(price) * amount)  # 可能要取整数
-        if balance.current_balance < volume and entrust_bs == "B":
+        if balance.enable_balance < volume and entrust_bs == "B":
             raise exceptions.TradeError(u"没有足够的现金进行操作")
         if amount == 0:
             raise exceptions.TradeError(u"数量不能为0")


### PR DESCRIPTION
enable_balance是可用金额，之前current_balance如果当天卖出的不会显示在这个金额里，余额检查就会报错